### PR TITLE
Describe BUILD_not_system option and define to ON by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ include(CMakeDependentOption)
 CMAKE_DEPENDENT_OPTION(BUILD_system "Build dependencies available on system package manager" OFF
 		"NOT BUILD_ALL" ON)
         
-CMAKE_DEPENDENT_OPTION(BUILD_not_system "Build dependencies not available on system package manager" OFF
+CMAKE_DEPENDENT_OPTION(BUILD_not_system "Build dependencies not available on system package manager" ON
 		"NOT BUILD_ALL" ON)
 
 CMAKE_DEPENDENT_OPTION(BUILD_sirius "Build sirius solver dependency Library" OFF

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Dependency are built at configure time using the option: `-DBUILD_ALL=ON` (`OFF`
 Libraries are compiled with static option (except for Sirius solver).
 
 Note:
-> You can build all system libraries with `-DBUILD_SYSTEM=ON`
+> You can build all system libraries with : `-DBUILD_SYSTEM=ON` (default `OFF`)
+> You can build libraries not available on system with `-DBUILD_not_system=ON` (default `ON`). Sirius solver and OR-Tools will be built.
 
 
 ## Defining dependency install directory

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -85,9 +85,12 @@ function(build_git_dependency)
   if(result)
     message(FATAL_ERROR "CMake step for ${GIT_DEP_NAME} failed: ${result}")
   endif()
+  
+  include(ProcessorCount)
+  ProcessorCount(NB_PROC)
 
   execute_process(
-    COMMAND ${CMAKE_COMMAND} --build project_build --config ${CMAKE_BUILD_TYPE}
+    COMMAND ${CMAKE_COMMAND} --build project_build --config ${CMAKE_BUILD_TYPE} -j ${NB_PROC}
     RESULT_VARIABLE result
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${GIT_DEP_NAME})
   if(result)


### PR DESCRIPTION
Use of -j when building librairies