### PR TITLE
Feature/use git 2 centos7

### DIFF
--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -36,13 +36,15 @@ jobs:
     - name: Install libraries
       run: |
            yum update -y
-           yum install -y https://packages.endpoint.com/rhel/7/os/x86_64/endpoint-repo-1.9-1.x86_64.rpm
            yum install -y git epel-release redhat-lsb-core autoconf automake libtool gtk2-devel gcc gcc-c++ make centos-release-scl scl-utils
            yum install -y cmake3 devtoolset-7
+           yum install -y rh-git227-git
 
     - name: Configure and build
       run: |
            source /opt/rh/devtoolset-7/enable
+           #git 2.x must be enabled for Coin compilation with CMake ExternalProject_Add
+           source /opt/rh/rh-git227/enable
            cmake3 -B _build -S . -DBUILD_ortools=${{ matrix.build_ortools }} -DBUILD_not_system=ON -DBUILD_system=${{ matrix.system_build }} -DCMAKE_BUILD_TYPE=${{ matrix.buildtype }} -DDEPS_INSTALL_DIR=rte-antares-deps-${{ matrix.buildtype }}
 
     - name: Archive upload

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -7,7 +7,6 @@ on:
       - feature/*
       - features/*
       - fix/*
-      - feature/use_git_2_centos7
 jobs:
 
   build:

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -37,6 +37,7 @@ jobs:
     - name: Install libraries
       run: |
            yum update -y
+           yum install -y https://packages.endpoint.com/rhel/7/os/x86_64/endpoint-repo-1.9-1.x86_64.rpm
            yum install -y git epel-release redhat-lsb-core autoconf automake libtool gtk2-devel gcc gcc-c++ make centos-release-scl scl-utils
            yum install -y cmake3 devtoolset-7
 

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -7,6 +7,7 @@ on:
       - feature/*
       - features/*
       - fix/*
+      - feature/use_git_2_centos7
 jobs:
 
   build:

--- a/.github/workflows/releasesCentos.yml
+++ b/.github/workflows/releasesCentos.yml
@@ -39,6 +39,7 @@ jobs:
     - name: Install libraries
       run: |
            yum update -y
+           yum install -y https://packages.endpoint.com/rhel/7/os/x86_64/endpoint-repo-1.9-1.x86_64.rpm
            yum install -y git epel-release redhat-lsb-core autoconf automake libtool gtk2-devel gcc gcc-c++ make centos-release-scl scl-utils
            yum install -y cmake3 devtoolset-7
 

--- a/.github/workflows/releasesCentos.yml
+++ b/.github/workflows/releasesCentos.yml
@@ -39,13 +39,15 @@ jobs:
     - name: Install libraries
       run: |
            yum update -y
-           yum install -y https://packages.endpoint.com/rhel/7/os/x86_64/endpoint-repo-1.9-1.x86_64.rpm
            yum install -y git epel-release redhat-lsb-core autoconf automake libtool gtk2-devel gcc gcc-c++ make centos-release-scl scl-utils
            yum install -y cmake3 devtoolset-7
+           yum install -y rh-git227-git
 
     - name: Configure and build
       run: |
            source /opt/rh/devtoolset-7/enable
+           #git 2.x must be enabled for Coin compilation with CMake ExternalProject_Add
+           source /opt/rh/rh-git227/enable
            cmake3 -B _build -S . -DBUILD_ortools=${{ matrix.build_ortools }} -DBUILD_not_system=ON -DBUILD_system=${{ matrix.system_build }} -DCMAKE_BUILD_TYPE=${{ matrix.buildtype }} -DDEPS_INSTALL_DIR=rte-antares-deps-${{ matrix.buildtype }}
 
     - name: Create archive

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,6 @@ else()
     endif()    
 endif()
 
-
 message(STATUS "DEPS_INSTALL_DIR : ${DEPS_INSTALL_DIR}")
 
 list(APPEND CMAKE_PREFIX_PATH ${DEPS_INSTALL_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ else()
     endif()    
 endif()
 
+
 message(STATUS "DEPS_INSTALL_DIR : ${DEPS_INSTALL_DIR}")
 
 list(APPEND CMAKE_PREFIX_PATH ${DEPS_INSTALL_DIR})

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Theses libraries can be installed from a package manager (apt-get for debian, yu
 - solver libraries: Sirius Solver, OR-Tools
 Theses libraries can't be installed from a package manager. They must be compiled from sources.
 
+## [Git version](#git-version)
+Git version must be above 2.x for external dependencies build because `--ignore-whitespace` is not used by default and we have an issue with OR-Tools compilation of ZLib and application of patch on Windows (see https://github.com/google/or-tools/issues/1193).
+
+This is also needed for coin checkout. Without git 2.x there are changes after git clone and there is an issue with CMake `ExternalProject_Add`
+
 ## Choose built libraries
 You can choose built librairies with these options :
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ You can choose built librairies with these options :
 
 Libraries are compiled with static option (except for Sirius solver because OR-Tools use of shared version of Sirius solver).
 
+
 ## CMake configure option
 
 Here is a list of other available CMake configure option :

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ You can choose built librairies with these options :
 
 Libraries are compiled with static option (except for Sirius solver because OR-Tools use of shared version of Sirius solver).
 
-
 ## CMake configure option
 
 Here is a list of other available CMake configure option :


### PR DESCRIPTION
CI was broken because CoinUtils git checkout is changing some file and we can't use `ExternalProject_Add` on this repository if git 1.x is used.
git 2.x is used by enabling rh-git227-git
