### PR TITLE
Rename minizip -> minizip-ng

### DIFF
--- a/cmake/dependencies/CMakeLists.txt
+++ b/cmake/dependencies/CMakeLists.txt
@@ -1,15 +1,15 @@
 #####################
 ##  minizip-ng  ##
 #####################
-find_package(minizip  )
-if(NOT minizip_FOUND)
+find_package(minizip-ng)
+if(NOT minizip-ng_FOUND)
     set(REPOSITORY "https://github.com/zlib-ng/minizip-ng.git")
         set(TAG "3.0.6")
         set(CMAKE_ARGS_MZ "-DCMAKE_INSTALL_PREFIX=${DEPS_INSTALL_DIR} -DMZ_LZMA=OFF -DMZ_ZSTD=OFF -DMZ_BZIP2=OFF -DMZ_PKCRYPT=OFF -DMZ_WZAES=OFF -DMZ_OPENSSL=OFF -DMZ_ICONV=OFF -DMZ_COMPAT=OFF")
 
         build_git_dependency(
             NAME
-            minizip
+            minizip-ng
             REPOSITORY
             ${REPOSITORY}
             TAG


### PR DESCRIPTION
Usage in projects
```cmake
# CMakeLists.txt
find_package(minizip-ng)
# mylib.cmake
add_library(mylib PRIVATE MINIZIP::minizip-ng)
```