### PR TITLE
Build boost also as shared libraries

### DIFF
--- a/cmake/dependencies/boost/CMakeLists.txt.in
+++ b/cmake/dependencies/boost/CMakeLists.txt.in
@@ -60,6 +60,6 @@ ExternalProject_Add(
 	# We set the following commands content (even with an empty string) : otherwise a default non convenient command is run.
 	UPDATE_COMMAND		${booststrap_script}
 	CONFIGURE_COMMAND	""
-	BUILD_COMMAND		${b2} address-model=64 architecture=x86 link=static --prefix=@DEPS_INSTALL_DIR@ install
+	BUILD_COMMAND		${b2} address-model=64 architecture=x86 link=static,shared --prefix=@DEPS_INSTALL_DIR@ install
 	INSTALL_COMMAND		""
 )


### PR DESCRIPTION
**Description**

Following https://github.com/AntaresSimulatorTeam/Antares_Simulator/pull/1560, we need Boost.Test as a shared library, in order to be able to execute unit tests without embedding the main in each executable.

Those libraries are usually included in installations from system package managers, but so far we only build static libraries here.