### PR TITLE
Fix windows debug build

### DIFF
--- a/.github/workflows/releasesWindows.yml
+++ b/.github/workflows/releasesWindows.yml
@@ -28,8 +28,12 @@ jobs:
         
     - name: Configure and build
       run: |
-           cmake -B _build -S . -DBUILD_not_system=ON -DBUILD_system=${{ matrix.system_build }} -DDEPS_INSTALL_DIR=rte-antares-deps-${{ matrix.buildtype }}
-           
+           cmake -B _build -S . \
+              -DCMAKE_BUILD_TYPE=${{ matrix.buildtype }} \
+              -DBUILD_not_system=ON \
+              -DBUILD_system=${{ matrix.system_build }} \
+              -DDEPS_INSTALL_DIR=rte-antares-deps-${{ matrix.buildtype }}
+
     - name: Create archive
       run: |
            Compress-Archive -Path rte-antares-deps-${{ matrix.buildtype }} -DestinationPath rte-antares-deps-${{ matrix.os }}-${{ matrix.buildtype }}.zip


### PR DESCRIPTION
**Description**

Libraries from the debug and release assets, in github release, are identical.

Actually, only release assets are produced. The build type was not correctly defined in cmake step.